### PR TITLE
fixes bug in resume method

### DIFF
--- a/src/plugin/components/ant-path.component.js
+++ b/src/plugin/components/ant-path.component.js
@@ -84,7 +84,12 @@ export default class AntPath extends FeatureGroup {
     }
 
     resume() {
-        this._calculateAnimationSpeed();
+        const {options} = this;
+        if (options.paused) {
+            options.paused = false;
+            this._calculateAnimationSpeed();
+        } else return false;
+        
     }
 
     _mount() {


### PR DESCRIPTION
`resume()` calls  `_calculateAnimationSpeed()`, which returns immediately if `options.paused == true`, so `resume()` doesn't work.  This fix sets `options.paused` to false before calling  `_calculateAnimationSpeed()`.

I have not tested it because I don't understand how to build the .js from source,  but I'm pretty sure it should work.