### PR TITLE
Pane Support and setStyle Fix

### DIFF
--- a/src/plugin/components/ant-path.component.js
+++ b/src/plugin/components/ant-path.component.js
@@ -23,7 +23,7 @@ export default class AntPath extends FeatureGroup {
     paused: false,
     reverse: false,
     hardwareAcceleration: false,
-    renderer: svg(),
+    pane: "overlayPane",
     delay: 400,
     dashArray: [10, 20],
     weight: 5,
@@ -95,7 +95,9 @@ export default class AntPath extends FeatureGroup {
   _mount() {
     const { pathOpts, pulseOpts } = this._processOptions();
     const { use } = this.options;
-
+    const renderer = svg({pane: this.options.pane})
+    pulseOpts.renderer = renderer
+    pathOpts.renderer = renderer
     this.addLayer((this[Layers.main] = use(this._path, pathOpts)));
     this.addLayer((this[Layers.pulse] = use(this._path, pulseOpts)));
   }
@@ -203,7 +205,13 @@ export default class AntPath extends FeatureGroup {
 
   //Polyline interface
   setStyle(options) {
-    const { paused, delay, reverse } = options;
+    let { paused, delay, reverse } = options;
+
+    // Set defaults if not passed in options
+    paused = (typeof paused === "undefined") ? this.options.paused:paused;
+    delay = (typeof delay === "undefined") ? this.options.delay:delay;
+    reverse = (typeof delay === "undefined") ? this.options.reverse:reverse;
+
     paused ? this.pause() : this.resume();
 
     if (delay !== this.options.delay) {

--- a/src/plugin/components/ant-path.component.js
+++ b/src/plugin/components/ant-path.component.js
@@ -23,7 +23,7 @@ export default class AntPath extends FeatureGroup {
     paused: false,
     reverse: false,
     hardwareAcceleration: false,
-    pane: "overlayPane",
+    renderer: svg({pane: "overlayPane"}),
     delay: 400,
     dashArray: [10, 20],
     weight: 5,
@@ -95,9 +95,7 @@ export default class AntPath extends FeatureGroup {
   _mount() {
     const { pathOpts, pulseOpts } = this._processOptions();
     const { use } = this.options;
-    const renderer = svg({pane: this.options.pane})
-    pulseOpts.renderer = renderer
-    pathOpts.renderer = renderer
+
     this.addLayer((this[Layers.main] = use(this._path, pathOpts)));
     this.addLayer((this[Layers.pulse] = use(this._path, pulseOpts)));
   }
@@ -205,13 +203,7 @@ export default class AntPath extends FeatureGroup {
 
   //Polyline interface
   setStyle(options) {
-    let { paused, delay, reverse } = options;
-
-    // Set defaults if not passed in options
-    paused = (typeof paused === "undefined") ? this.options.paused:paused;
-    delay = (typeof delay === "undefined") ? this.options.delay:delay;
-    reverse = (typeof delay === "undefined") ? this.options.reverse:reverse;
-
+    const { paused, delay, reverse } = {...this.options, ...options};
     paused ? this.pause() : this.resume();
 
     if (delay !== this.options.delay) {


### PR DESCRIPTION
Added default option `pane`. Moved `renderer` assignment from `_defaultOptions` to `_mount` with assigned pane. Assigned defaults in `setStyle` for `paused`, `delay` and `reverse`. The object's properties were not being carried over when `setStyle` was called resulting in the default properties being used leading to unwanted behavior.