### PR TITLE
Added Zoom Level Check To Prevent Animation Stopping

### DIFF
--- a/src/plugin/components/ant-path.component.js
+++ b/src/plugin/components/ant-path.component.js
@@ -107,7 +107,12 @@ export default class AntPath extends FeatureGroup {
       return;
     }
 
-    const zoomLevel = _map.getZoom();
+    // Use a minimum acceptable zoom level to prevent path animation from stopping when zoomLevel <= 0
+    // This may occur when using animations layered on ImageOverlay maps using CRS.Simple coordinates
+    // NOTE User may need to adjust options.delay under these conditions to achieve desired animation behavior
+    const minimumZoomLevel = 4;
+
+    const zoomLevel = Math.max(minimumZoomLevel, _map.getZoom());
     const animatedPolyElements = document.getElementsByClassName(_animatedPathId);
 
     //Get the animation duration (in seconds) based on the given delay and the current zoom level


### PR DESCRIPTION
Added minimum zoom level check to prevent animation stopping when zoomLevel <=0.

I set the minimumZoomLevel at 4, since it gave the most visually appealing results in my opinion.
It could be any integer >= 1 or even set by the user in the options object if you think that's better design.

Code works using webpack server via `npm start`  and all tests pass via `npm test`

`
HeadlessChrome 72.0.3617 (Linux 0.0.0): Executed 17 of 17 SUCCESS (0.172 secs / 0.044 secs)
TOTAL: 17 SUCCESS
`

Closes #90.