### PR TITLE
make path IDs static, so they are always unique

### DIFF
--- a/src/plugin/components/ant-path.component.js
+++ b/src/plugin/components/ant-path.component.js
@@ -32,12 +32,14 @@ export default class AntPath extends FeatureGroup {
     pulseColor: "#FFFFFF"
   };
 
+  static pathId = 0;
+
   constructor(path, customOptions = {}) {
     super();
 
     Util.setOptions(this, { ...this._defaultOptions, ...customOptions });
     this._path = path;
-    this._animatedPathId = `ant-path-${new Date().getTime()}`;
+    this._animatedPathId = `ant-path-${AntPath.pathId++}`;
     this._mount();
   }
 


### PR DESCRIPTION
Changed creation of the path IDs to use a static variable, instead of the date time.
Before this change, paths could be given the same ID if created within the same millisecond.
Closes #86