### PR TITLE
Add Script Inclusion process to Readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ Via Bower:
  bower install leaflet-ant-path
 ```
 
+## Including
+Via HTML Script (Include the Ant-Path's script after Leaflet's):
+```
+<script src="https://unpkg.com/leaflet-ant-path" type="text/javascript"></script>
+```
 Or just [download](https://github.com/rubenspgcavalcante/leaflet-ant-path-bower/archive/master.zip) this source code
 
 


### PR DESCRIPTION
Adds the script's inclusion method to use without npm or node, just the remote source code so people can use on plain html. 
Closes #134 